### PR TITLE
Padding to Step's text added.

### DIFF
--- a/docs/src/components/Homepage/index.tsx
+++ b/docs/src/components/Homepage/index.tsx
@@ -83,24 +83,24 @@ const Homepage = () => {
             description="As your project grows, you can upgrade your plan to get more storage and more bandwidth."
           />
         </div>
-        <div className="flex flex-col items-center justify-center max-w-md -z-10">
+        <div className="flex flex-col items-center justify-center max-w-md -z-10 text-center">
           <h2>Step 1 - Server</h2>
-          <div className="text-gray-300">
+          <div className="text-gray-300 px-8">
             Add the service environment variables to your Next.js app. Then
             export the Edge Store API from the Next.js API routes.
           </div>
           <div className="mb-6" />
           <h2>Step 2 - Client</h2>
-          <div className="text-gray-300">
+          <div className="text-gray-300 px-8">
             Wrap your app with the Edge Store provider component. This will
             enable you to access Edge Store methods anywhere in your app.
           </div>
           <div className="mb-6" />
           <h2>Step 3 - Start using</h2>
-          <div className="text-gray-300">
+          <div className="text-gray-300 px-8">
             Use the useEdgeStore hook to upload and fetch images from Edge
             Store. You can also use Edge Store features like:
-            <ul>
+            <ul className="text-start">
               <li>Getting real-time progress of image uploads</li>
               <li>Controlling access to images with permissions</li>
               <li>Optimizing images for different devices and resolutions</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17756,7 +17756,7 @@
     },
     "packages/react": {
       "name": "@edge-store/react",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.294.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17756,7 +17756,7 @@
     },
     "packages/react": {
       "name": "@edge-store/react",
-      "version": "0.0.0-alpha.8",
+      "version": "0.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.294.0",


### PR DESCRIPTION
The text in the step part of the landing page especially in mobile devices looks very suffocated it has little to no space.

Before
![image](https://github.com/edgestorejs/edge-store/assets/85099589/ebe25403-bb31-4f54-b9a7-cd6c406d9d67)

After
![image](https://github.com/edgestorejs/edge-store/assets/85099589/478835af-e888-4437-899e-dfafbed12054)

I also centered the text so it looks cleaner.

